### PR TITLE
[dist] use swaagie/base:v0.15.0 to update to ubuntu@18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM quay.io/justcontainers/base:v0.14.0
+FROM swaagie/base:v0.15.0
 
-RUN sudo apt-get update && sudo apt-get install --fix-missing -y curl
+RUN apt-get update && apt-get install --fix-missing -y curl gnupg
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && sudo apt-get install -y nodejs
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && apt-get install -y nodejs
 
 # Use the latest npm
 RUN npm i -g npm@6


### PR DESCRIPTION
`sudo` is no longer needed by default it seems, also `gpg` was required for installing the custom key from Nodesource.

`FROM swaagie/base:v0.15.0` is a fork of https://github.com/just-containers/base/blob/master/Dockerfile 
`FROM swaagie/base-without-s6:v18.04` is a fork of https://github.com/just-containers/base-without-s6/blob/master/Dockerfile so we don't have to wait for an OS update.